### PR TITLE
Add log detail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ gopose up --dry-run
 # 詳細ログ出力
 gopose up --verbose
 
+# 詳細情報を含めて表示
+gopose up --detail # タイムスタンプやフィールドを含めて表示
+
 # JSON形式で状態確認
 gopose status --output json
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 var (
 	cfgFile string
 	verbose bool
+	detail  bool
 )
 
 // rootCmd はルートコマンドを表します。
@@ -54,6 +55,7 @@ func init() {
 	// グローバルフラグの定義
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "設定ファイルのパス (デフォルト: $HOME/.gopose.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "詳細ログ出力")
+	rootCmd.PersistentFlags().BoolVar(&detail, "detail", false, "ログの詳細情報を表示")
 
 	// 各サブコマンドをルートコマンドに追加
 	rootCmd.AddCommand(upCmd)
@@ -108,6 +110,6 @@ func getConfig() types.Config {
 
 // getLogger はロガーを取得します。
 func getLogger(cfg types.Config) (logger.Logger, error) {
-	factory := logger.NewStructuredLoggerFactory()
+	factory := logger.NewStructuredLoggerFactory(detail)
 	return factory.Create(cfg.GetLog())
 }

--- a/internal/logger/structured.go
+++ b/internal/logger/structured.go
@@ -14,17 +14,21 @@ import (
 
 // StructuredLogger は構造化ログの実装です。
 type StructuredLogger struct {
-	logger *slog.Logger
-	fields []types.Field
-	err    error
+	logger   *slog.Logger
+	fields   []types.Field
+	err      error
+	detailed bool
 }
 
 // StructuredLoggerFactory は構造化ログのファクトリです。
-type StructuredLoggerFactory struct{}
+type StructuredLoggerFactory struct {
+	detailed bool
+}
 
 // NewStructuredLoggerFactory は新しいファクトリを作成します。
-func NewStructuredLoggerFactory() *StructuredLoggerFactory {
-	return &StructuredLoggerFactory{}
+// detailed が false の場合、ログ出力はメッセージのみとなります。
+func NewStructuredLoggerFactory(detailed bool) *StructuredLoggerFactory {
+	return &StructuredLoggerFactory{detailed: detailed}
 }
 
 // Create は設定に基づいてロガーを作成します。
@@ -63,8 +67,9 @@ func (f *StructuredLoggerFactory) CreateWithName(name string, config types.LogCo
 	logger := slog.New(handler).With("component", name)
 
 	return &StructuredLogger{
-		logger: logger,
-		fields: []types.Field{},
+		logger:   logger,
+		fields:   []types.Field{},
+		detailed: f.detailed,
 	}, nil
 }
 
@@ -149,6 +154,11 @@ func (l *StructuredLogger) WithError(err error) Logger {
 
 // log は実際のログ出力を行います。
 func (l *StructuredLogger) log(ctx context.Context, level slog.Level, message string, fields ...types.Field) {
+	if !l.detailed {
+		fmt.Println(message)
+		return
+	}
+
 	// コンテキストから追加情報を取得
 	attrs := make([]slog.Attr, 0)
 


### PR DESCRIPTION
## Summary
- add `--detail` flag to control log metadata display
- default logs now show only messages unless `--detail` is used
- document `--detail` usage and clarify README

## Testing
- `go test ./...`
- `make run-help` (shows new flag)
- ran `gopose up --dry-run` with and without `--detail` to verify output behavior


------
https://chatgpt.com/codex/tasks/task_e_68478cbc6ab083299262c2d9036caf47