### PR TITLE
ポート定義での環境変数展開をサポート

### DIFF
--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -293,16 +293,60 @@ func (p *YamlComposeParser) parsePortMapping(ctx context.Context, portInterface 
 	}
 }
 
+// expandVariables は文字列内の環境変数を展開します。
+// ${VAR:-default} や $VAR の形式をサポートします。
+func expandVariables(input string) string {
+	// ${VAR:-default} 形式の変数を展開
+	varWithDefaultRe := regexp.MustCompile(`\$\{([^}]+):-([^}]*)\}`)
+	expanded := varWithDefaultRe.ReplaceAllStringFunc(input, func(match string) string {
+		submatches := varWithDefaultRe.FindStringSubmatch(match)
+		if len(submatches) == 3 {
+			varName := submatches[1]
+			defaultValue := submatches[2]
+			if value := os.Getenv(varName); value != "" {
+				return value
+			}
+			return defaultValue
+		}
+		return match
+	})
+
+	// ${VAR} 形式の変数を展開
+	varRe := regexp.MustCompile(`\$\{([^}]+)\}`)
+	expanded = varRe.ReplaceAllStringFunc(expanded, func(match string) string {
+		submatches := varRe.FindStringSubmatch(match)
+		if len(submatches) == 2 {
+			return os.Getenv(submatches[1])
+		}
+		return match
+	})
+
+	// $VAR 形式の変数を展開
+	simpleVarRe := regexp.MustCompile(`\$([A-Za-z_][A-Za-z0-9_]*)`)
+	expanded = simpleVarRe.ReplaceAllStringFunc(expanded, func(match string) string {
+		submatches := simpleVarRe.FindStringSubmatch(match)
+		if len(submatches) == 2 {
+			return os.Getenv(submatches[1])
+		}
+		return match
+	})
+
+	return expanded
+}
+
 // parsePortString は文字列形式のポートマッピングを解析します。
 func (p *YamlComposeParser) parsePortString(ctx context.Context, portStr string) (*types.PortMapping, error) {
-	// 例: "8080:80", "8080:80/tcp", "127.0.0.1:8080:80"
+	// 例: "8080:80", "8080:80/tcp", "127.0.0.1:8080:80", "${PORT:-3000}:80"
+
+	// 環境変数を展開
+	expandedPortStr := expandVariables(portStr)
 
 	protocol := "tcp"
-	portPart := portStr
+	portPart := expandedPortStr
 
 	// プロトコル部分を分離
-	if strings.Contains(portStr, "/") {
-		parts := strings.Split(portStr, "/")
+	if strings.Contains(expandedPortStr, "/") {
+		parts := strings.Split(expandedPortStr, "/")
 		if len(parts) == 2 {
 			portPart = parts[0]
 			protocol = parts[1]
@@ -316,7 +360,7 @@ func (p *YamlComposeParser) parsePortString(ctx context.Context, portStr string)
 	if len(matches) == 0 {
 		return nil, &errors.AppError{
 			Code:    errors.ErrParseFailed,
-			Message: fmt.Sprintf("無効なポート形式: %s", portStr),
+			Message: fmt.Sprintf("無効なポート形式: %s (展開後: %s)", portStr, expandedPortStr),
 		}
 	}
 

--- a/internal/parser/yaml_test.go
+++ b/internal/parser/yaml_test.go
@@ -1,0 +1,169 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/harakeishi/gopose/internal/logger"
+	"github.com/harakeishi/gopose/pkg/types"
+)
+
+func TestExpandVariables(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			name:     "環境変数の展開 - デフォルト値あり",
+			input:    "${APP_PORT:-3000}:80",
+			envVars:  map[string]string{},
+			expected: "3000:80",
+		},
+		{
+			name:     "環境変数の展開 - 環境変数が設定されている",
+			input:    "${APP_PORT:-3000}:80",
+			envVars:  map[string]string{"APP_PORT": "4000"},
+			expected: "4000:80",
+		},
+		{
+			name:     "環境変数の展開 - ${VAR}形式",
+			input:    "${PORT}:80",
+			envVars:  map[string]string{"PORT": "5000"},
+			expected: "5000:80",
+		},
+		{
+			name:     "環境変数の展開 - $VAR形式",
+			input:    "$PORT:80",
+			envVars:  map[string]string{"PORT": "6000"},
+			expected: "6000:80",
+		},
+		{
+			name:     "環境変数の展開 - 複数の変数",
+			input:    "${HOST_PORT:-8080}:${CONTAINER_PORT:-80}",
+			envVars:  map[string]string{"HOST_PORT": "9090"},
+			expected: "9090:80",
+		},
+		{
+			name:     "環境変数なし",
+			input:    "3000:80",
+			envVars:  map[string]string{},
+			expected: "3000:80",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 環境変数をセット
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			result := expandVariables(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandVariables(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParsePortString(t *testing.T) {
+	factory := logger.NewStructuredLoggerFactory(false)
+	testLogger, _ := factory.Create(types.LogConfig{})
+	parser := NewYamlComposeParser(testLogger)
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		input    string
+		envVars  map[string]string
+		expected *types.PortMapping
+		hasError bool
+	}{
+		{
+			name:    "環境変数展開 - デフォルト値",
+			input:   "${APP_PORT:-3000}:80",
+			envVars: map[string]string{},
+			expected: &types.PortMapping{
+				Host:      3000,
+				Container: 80,
+				Protocol:  "tcp",
+			},
+			hasError: false,
+		},
+		{
+			name:    "環境変数展開 - 環境変数が設定済み",
+			input:   "${APP_PORT:-3000}:80",
+			envVars: map[string]string{"APP_PORT": "4000"},
+			expected: &types.PortMapping{
+				Host:      4000,
+				Container: 80,
+				Protocol:  "tcp",
+			},
+			hasError: false,
+		},
+		{
+			name:    "通常のポート形式",
+			input:   "8080:80",
+			envVars: map[string]string{},
+			expected: &types.PortMapping{
+				Host:      8080,
+				Container: 80,
+				Protocol:  "tcp",
+			},
+			hasError: false,
+		},
+		{
+			name:    "IPアドレス付き環境変数",
+			input:   "127.0.0.1:${PORT:-3000}:80",
+			envVars: map[string]string{},
+			expected: &types.PortMapping{
+				Host:      3000,
+				Container: 80,
+				Protocol:  "tcp",
+				HostIP:    "127.0.0.1",
+			},
+			hasError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 環境変数をセット
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			result, err := parser.parsePortString(ctx, tt.input)
+
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("parsePortString(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parsePortString(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+
+			if result.Host != tt.expected.Host {
+				t.Errorf("parsePortString(%q) Host = %d, want %d", tt.input, result.Host, tt.expected.Host)
+			}
+
+			if result.Container != tt.expected.Container {
+				t.Errorf("parsePortString(%q) Container = %d, want %d", tt.input, result.Container, tt.expected.Container)
+			}
+
+			if result.Protocol != tt.expected.Protocol {
+				t.Errorf("parsePortString(%q) Protocol = %q, want %q", tt.input, result.Protocol, tt.expected.Protocol)
+			}
+
+			if result.HostIP != tt.expected.HostIP {
+				t.Errorf("parsePortString(%q) HostIP = %q, want %q", tt.input, result.HostIP, tt.expected.HostIP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Docker Composeファイルのポート定義で環境変数（${VAR:-default}形式）が使用できず解析エラーが発生していた問題を修正。

### 変更内容
- `expandVariables`関数を追加し、3種類の環境変数形式に対応
  - `${VAR:-default}`: デフォルト値付き環境変数
  - `${VAR}`: 環境変数
  - `$VAR`: シンプルな環境変数記法
- `parsePortString`関数で解析前に環境変数を展開
- より詳細なエラーメッセージ（展開前と展開後の値を表示）
- 包括的なテストケースを追加（`internal/parser/yaml_test.go`）

### 期待すること
- `${APP_PORT:-3000}:80`のような環境変数を含むポート定義が正常に解析される
- 環境変数が設定されていない場合はデフォルト値が使用される
- 環境変数が設定されている場合はその値が優先される
- 既存のポート形式（固定値）は引き続き正常動作する

### 動作確認

| 項目 | 証憑(スクショなど) | 備考 |
| -- | -- | -- |
| 環境変数展開テスト | テスト結果: `go test ./internal/parser -v` PASS | 6つのテストケースすべて成功 |
| ポート解析テスト | テスト結果: `go test ./internal/parser -v` PASS | 4つのテストケースすべて成功 |
| ビルドテスト | `make build` 成功 | アプリケーション全体のビルドが正常完了 |